### PR TITLE
Improve step reporting

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -38,7 +38,8 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - id: spelling
+    - id: validate
+      name: Validate
       env:
         DHALL_HASKELL: ${{ inputs.dhall-haskell }}
         DHALL_JSON: ${{ inputs.dhall-json }}


### PR DESCRIPTION
The `id` should be changed no matter what (we just used check-spelling as a starting point...).

The [`name` field](https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runsstepsname) is defined, but doesn't seem to be exposed visibly (it might be in other logs?), but we should fill it out anyway.

<details><summary>I'll probably file a bug that the `name` field doesn't mask the `run` at some point...</summary>

https://github.com/check-spelling/check-spelling/actions/runs/3454444543/jobs/5765750694#step:3:1
```
▼Run cp -R . ../introspected/; mv ../introspected .
  cp -R . ../introspected/; mv ../introspected .
  shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
```
https://github.com/check-spelling/check-spelling/blob/43b5df4e970520bb0aea03cf8cf21d0e548b71eb/.github/workflows/spelling.yml#L29-L33

```yaml
    - name: test-clean
      shell: bash
      run:
        cp -R . ../introspected/;
        mv ../introspected .
```
</details>