### PR TITLE
Restructure validation workflow

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -1,4 +1,5 @@
 Cwd
+emoji
 endgroup
 jsoref
 Linting

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -8,24 +8,54 @@ on:
   pull_request_target:
 
 jobs:
-  validate-files:
-    name: Validate Files
+  good-file:
+    name: Validate Good File
     runs-on: ubuntu-latest
-    continue-on-error: true
     permissions:
       contents: read
+    outputs:
+      validated: ${{ steps.validate.outcome }}
+      expected: success
     steps:
     - name: checkout-merge
-      if: "contains(github.event_name, 'pull_request')"
+      if: contains(github.event_name, 'pull_request')
       uses: actions/checkout@v4
       with:
         ref: refs/pull/${{github.event.pull_request.number}}/merge
     - name: checkout
-      if: "!contains(github.event_name, 'pull_request')"
+      if: ${{ !contains(github.event_name, 'pull_request') }}
       uses: actions/checkout@v4
       with:
         ref: ${{ github.event.pull_request.head.sha }}
     - name: dhall-validator-files
+      id: validate
+      continue-on-error: true
+      uses: ./
+      with:
+        dhall-files: tests/pass.dhall
+        verbose: 1
+  validate-files:
+    name: Validate Files
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      validated: ${{ steps.validate.outcome }}
+      expected: failure
+    steps:
+    - name: checkout-merge
+      if: contains(github.event_name, 'pull_request')
+      uses: actions/checkout@v4
+      with:
+        ref: refs/pull/${{github.event.pull_request.number}}/merge
+    - name: checkout
+      if: ${{ !contains(github.event_name, 'pull_request') }}
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+    - name: dhall-validator-files
+      id: validate
+      continue-on-error: true
       uses: ./
       with:
         dhall-files: |
@@ -37,15 +67,17 @@ jobs:
   validate-list:
     name: Validate List
     runs-on: ubuntu-latest
-    continue-on-error: true
+    outputs:
+      validated: ${{ steps.validate.outcome }}
+      expected: failure
     steps:
     - name: checkout-merge
-      if: "contains(github.event_name, 'pull_request')"
+      if: contains(github.event_name, 'pull_request')
       uses: actions/checkout@v4
       with:
         ref: refs/pull/${{github.event.pull_request.number}}/merge
     - name: checkout
-      if: "!contains(github.event_name, 'pull_request')"
+      if: ${{ !contains(github.event_name, 'pull_request') }}
       uses: actions/checkout@v4
       with:
         ref: ${{ github.event.pull_request.head.sha }}
@@ -60,22 +92,44 @@ jobs:
         git -C dhall-lang ls-files 'tests/parser/*/unit/Bool*.dhall' -z |
         perl -e '$/="\0"; while (<>) {s#^#dhall-lang/#; print}' > /tmp/dhall-files.list
     - name: dhall-validator-list
+      id: validate
+      continue-on-error: true
       uses: ./
       with:
         dhall-file-list: /tmp/dhall-files.list
-  collect-results:
-    name: Collect Results
+  check-results:
+    name: Check Results
     runs-on: ubuntu-latest
     needs:
+      - good-file
       - validate-files
       - validate-list
     if: success() || failure()
     steps:
-    - name: Check for failing to catch validation errors
-      if: needs.validate-files.outcome == 'success' || needs.validate-list.outcome == 'success'
+    - name: Report
+      env:
+        GOOD_ACTUAL: ${{ needs.good-file.outputs.validated }}
+        GOOD_EXPECTED: ${{ needs.good-file.outputs.expected }}
+        FILES_ACTUAL: ${{ needs.validate-files.outputs.validated }}
+        FILES_EXPECTED: ${{ needs.validate-files.outputs.expected }}
+        LIST_ACTUAL: ${{ needs.validate-list.outputs.validated }}
+        LIST_EXPECTED: ${{ needs.validate-list.outputs.expected }}
+        EXPECTED: ${{ needs.good-file.outputs.validated == needs.good-file.outputs.expected && needs.validate-files.outputs.validated == needs.validate-files.outputs.expected && needs.validate-list.outputs.validated == needs.validate-list.outputs.expected }}
       run: |
-        echo "::error::Failed to catch validation errors"
-        exit 1
-    - name: Report success
-      run: |
-        echo "::notice::Validation properly caught errors"
+        : Check for failing to catch validation errors
+        github_results_to_emoji() {
+          perl -pe 's/success/:white_check_mark:/g;s/failure/:x:/g'
+        }
+        (
+          echo '# Results'
+          echo 'Test|Result|Expected'
+          echo '-|-|-'
+          echo "Good Files|$GOOD_ACTUAL|$GOOD_EXPECTED"
+          echo "Files|$FILES_ACTUAL|$FILES_EXPECTED"
+          echo "File List|$LIST_ACTUAL|$LIST_EXPECTED"
+        ) | github_results_to_emoji >> "$GITHUB_STEP_SUMMARY"
+        if [ "$EXPECTED" != true ]; then
+          echo "::error::Failed to properly perform validation"
+          exit 1
+        fi
+        echo "::notice::Validation properly handled good and bad cases"

--- a/check.sh
+++ b/check.sh
@@ -49,7 +49,7 @@ if [ -z "$LIST" ]; then
   export LIST=$(mktemp)
 fi
 if [ -n "$FILES" ]; then
-  echo "$FILES" | tr "\n" "\0" >> "$LIST"
+  echo "$FILES" | grep . | tr "\n" "\0" >> "$LIST"
 fi
 
 if ! grep -q . "$LIST"; then


### PR DESCRIPTION
The `validate` workflow needs to do three things:

1. Prove that given only good files, validation passes (✅)
2. Given a mix of good/bad files (in the `dhall-files` input), validation fails (❌)
3. Given at least some bad files (in a file referenced by the `dhall-file-list` input), validation fails (❌)

Ideally, it does this in a manner that doesn't confuse people into thinking that a commit to the default branch is "broken". Unfortunately, negative testing is pretty confusing.

Previously, negative testing was done by setting `continue-on-error: true` at the job level, but that resulted in ❌s being shown on the commit.

This PR changes the logic so that only the `uses: ./` step has `continue-on-error: true`.
Each job is given two outputs: `validated:` (the result of that step) and `expected:` (with the expected outcome for that step).

The check results job then collects all the results and compares them with their expected results. Because we can, it produces a pretty table.

Note that I intend to give the action itself pretty reporting at some time too, but that's outside the scope of this PR.