### PR TITLE
Ask dhall lint to show its cards

### DIFF
--- a/check.sh
+++ b/check.sh
@@ -36,12 +36,11 @@ fi
 
 if [ -n "$LINT" ]; then
   echo "::group::lint"
-  if cat "$LIST" | xargs -0 dhall lint --check; then
-    echo '::notice::Linting passed.'
-  else
+  if ! cat "$LIST" | xargs -0 "$GITHUB_ACTION_PATH/dhall-linter"; then
     echo '::error::Linting failed. Use `dhall lint` locally to fix the errors.'
     exit 1
   fi
+  echo '::notice::Linting passed.'
   echo "::endgroup::"
 fi
 

--- a/dhall-linter
+++ b/dhall-linter
@@ -1,0 +1,9 @@
+#!/bin/sh
+baseline=$(mktemp)
+git status > "$baseline" || true
+dhall lint "$@"
+updated=$(mktemp)
+git status > "$updated" || true
+diff -u "$baseline" "$updated" || true
+echo
+git diff --exit-code -- "$@"


### PR DESCRIPTION
`dhall lint --check` appears to be inconsistently opinionated.

Instead, get a baseline, ask `dhall lint` to rewrite files, and then compare the state of the world before/after, and finally compare the files that dhall lint potentially rewrote.